### PR TITLE
8.0 4171 colli info per carrier

### DIFF
--- a/delivery_transsmart/__openerp__.py
+++ b/delivery_transsmart/__openerp__.py
@@ -39,6 +39,7 @@
         "views/service_level_views.xml",
         "views/res_config_views.xml",
         "views/delivery_web_service_views.xml",
+        "views/res_partner.xml",
         "data/data.xml",
     ],
     'demo': [],

--- a/delivery_transsmart/models/__init__.py
+++ b/delivery_transsmart/models/__init__.py
@@ -27,4 +27,4 @@ from . import res_config
 from . import res_partner
 from . import stock_return_picking
 from . import delivery_web_service
-from . import transsmart_package_type
+from . import delivery_package_type

--- a/delivery_transsmart/models/__init__.py
+++ b/delivery_transsmart/models/__init__.py
@@ -27,3 +27,4 @@ from . import res_config
 from . import res_partner
 from . import stock_return_picking
 from . import delivery_web_service
+from . import transsmart_package_type

--- a/delivery_transsmart/models/delivery_package_type.py
+++ b/delivery_transsmart/models/delivery_package_type.py
@@ -4,8 +4,8 @@
 from openerp import fields, models
 
 
-class TranssmartPackageType(models.Model):
-    _name = 'transsmart.package.type'
+class DeliveryPackageType(models.Model):
+    _name = 'delivery.package.type'
     _description = 'Package types accepted by Transsmart'
 
     name = fields.Char()

--- a/delivery_transsmart/models/delivery_web_service.py
+++ b/delivery_transsmart/models/delivery_web_service.py
@@ -25,12 +25,57 @@ from openerp.exceptions import Warning
 import logging
 
 _logger = logging.getLogger(__name__)
+TRANS_API_ENDPOINTS = {
+        'delivery.service.level': 'ServiceLevelOther',
+        'delivery.service.level.time': 'ServiceLevelTime',
+        'res.partner': 'Carrier',
+        'transsmart.cost.center': 'Costcenter',
+        'delivery.package.type': 'Package',}
+TRANS_MODELS_LOCAL = [
+        'delivery.service.level',
+        'delivery.service.level.time',
+        'res.partner',
+        'transsmart.cost.center',
+        'delivery.package.type',
+        ]
+TRANS_MODELS_VALS = {
+        'delivery.service.level':{'code': 'Code',
+            'name': 'Name',
+            'transsmart_id': 'Id',
+            },
+        'delivery.service.level.time': {'code': 'Code',
+            'name': 'Name',
+            'transsmart_id': 'Id',
+            },
+        'res.partner': {'transsmart_code': 'Code',
+            'name': 'Name',
+            'supplier': True,
+            'customer': False,
+            'is_company': True,
+            'transsmart_id': 'Id',
+            'category_id': [(4, )],
+            },
+        'transsmart.cost.center': {'code': 'Code',
+            'name': 'Name',
+            'transsmart_id': 'Id',
+            },
+        'delivery.package.type': {'name': 'Name',
+            'package_type': 'Type',
+            'length': 'Length',
+            'width': 'Width',
+            'height': 'Height',
+            'weight': 'Weight',
+            'is_default': 'IsDefault',
+            'transsmart_id': 'Id',
+            },
+        }
+
 
 class DeliveryWebService(models.Model):
     _name = 'delivery.web.service'
 
     name = fields.Char(string="Title", required=True)
-    url = fields.Char(string="URL", required=True, default="https://connect.test.api.transwise.eu/Api")
+    url = fields.Char(string="URL", required=True, default="https://connect.test.api.transwise.eu/Api/")
     username = fields.Char(string="Username", required=True)
     password = fields.Char(string="Password", required=True)
 

--- a/delivery_transsmart/models/res_config.py
+++ b/delivery_transsmart/models/res_config.py
@@ -108,28 +108,10 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
     def get_transsmart_carrier_tag(self):
         return self.env.ref(
                 'delivery_transsmart.res_partner_category_transsmart_carrier'
-                ).id
-
-    def _get_odata_filter(self, transsmart_ids):
-        """
-        assembling an odata $filter
-        http://www.odata.org/documentation/
-        odata-version-2-0/uri-conventions/
-
-        Gets all the records that their Id is not in transsmart_ids
-        """
-        _filter = ''
-        for index, code in enumerate(transsmart_ids):
-            if index < len(transsmart_ids) - 1:
-                _and = ' and '
-            else:
-                _and = ''
-            _filter += 'Id ne {}{}'.format(transsmart_ids[index], _and)
-        return _filter
+        ).id
 
     @api.multi
     def sync_transsmart_models(self):
-        update_local_data = True
         delivery_service_level_model = self.env['delivery.service.level']
         delivery_service_level_time_model = self.env[
                 'delivery.service.level.time']
@@ -138,10 +120,8 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
         transsmart_package_type_model = self.env['transsmart.package.type']
         local_data = delivery_service_level_model.search([])
         local_transsmart_ids = [local.transsmart_id for local in local_data]
-        params = {'$filter': self._get_odata_filter(local_transsmart_ids)}
         remote_data = self.get_transsmart_service().receive(
-            '/ServiceLevelOther',
-            params=params if not update_local_data else {})
+                '/ServiceLevelOther')
         for data in remote_data:
             vals = {'code': data['Code'],
                     'name': data['Name'],
@@ -158,10 +138,8 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
 
         local_data = delivery_service_level_time_model.search([])
         local_transsmart_ids = [local.transsmart_id for local in local_data]
-        params = {'$filter': self._get_odata_filter(local_transsmart_ids)}
         remote_data = self.get_transsmart_service().receive(
-            '/ServiceLevelTime',
-            params=params if not update_local_data else {})
+                '/ServiceLevelTime')
         for data in remote_data:
             vals = {'code': data['Code'],
                     'name': data['Name'],
@@ -182,10 +160,7 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
         local_data = res_partner_model.search(
                 [('transsmart_id', 'not in', [None, 0])])
         local_transsmart_ids = [local.transsmart_id for local in local_data]
-        params = {'$filter': self._get_odata_filter(local_transsmart_ids)}
-        remote_data = self.get_transsmart_service().receive(
-                '/Carrier',
-                params=params if not update_local_data else {})
+        remote_data = self.get_transsmart_service().receive('/Carrier')
         for data in remote_data:
             vals = {'transsmart_code': data['Code'],
                     'name': data['Name'],
@@ -206,10 +181,7 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
 
         local_data = transsmart_cost_center_model.search([])
         local_transsmart_ids = [local.transsmart_id for local in local_data]
-        params = {'$filter': self._get_odata_filter(local_transsmart_ids)}
-        remote_data = self.get_transsmart_service().receive(
-            '/Costcenter',
-            params=params if not update_local_data else {})
+        remote_data = self.get_transsmart_service().receive('/Costcenter')
         for data in remote_data:
             vals = {'code': data['Code'],
                     'name': data['Name'],
@@ -226,10 +198,7 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
         # get the packages (box, pallet etc...)
         local_data = transsmart_package_type_model.search([])
         local_transsmart_ids = [local.transsmart_id for local in local_data]
-        params = {'$filter': self._get_odata_filter(local_transsmart_ids)}
-        remote_data = self.get_transsmart_service().receive(
-                '/Package',
-                params=params if not update_local_data else {})
+        remote_data = self.get_transsmart_service().receive('/Package')
         for data in remote_data:
             vals = {'name': data['Name'],
                     'package_type': data['Type'],

--- a/delivery_transsmart/models/res_config.py
+++ b/delivery_transsmart/models/res_config.py
@@ -23,8 +23,11 @@
 from openerp import models, fields, api, _
 from openerp.exceptions import Warning
 import logging
+from .delivery_web_service import TRANS_API_ENDPOINTS, TRANS_MODELS_LOCAL, \
+        TRANS_MODELS_VALS
 
 _logger = logging.getLogger(__name__)
+
 
 class DeliveryTranssmartConfiguration(models.TransientModel):
     _name = 'delivery.transsmart.config.settings'
@@ -46,6 +49,7 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
         string='Connection',
         help='Transsmart connection for this Odoo instance'
     )
+    log = fields.Text(string='Synchronisation log')
 
     @api.multi
     def get_default_transsmart(self):
@@ -110,114 +114,42 @@ class DeliveryTranssmartConfiguration(models.TransientModel):
                 'delivery_transsmart.res_partner_category_transsmart_carrier'
         ).id
 
+    def _sync_transsmart_model(self, model_name):
+        model_obj = self.env[model_name]
+        if model_name == 'res.partner':
+            local_data = model_obj.search([
+                ('transsmart_id', 'not in', [None, 0])])
+        else:
+            local_data = model_obj.search([])
+        local_transsmart_ids = [local.transsmart_id for local in local_data]
+        remote_data = self.get_transsmart_service().receive(
+                TRANS_API_ENDPOINTS[model_name])
+        for data in remote_data:
+            template_vals = TRANS_MODELS_VALS[model_name]
+            vals = {}
+            for key in template_vals.keys():
+                if key == 'category_id':
+                    vals[key] = [(4, self.get_transsmart_carrier_tag())]
+                    continue
+                if template_vals[key] in [False, True]:
+                    vals[key] = template_vals[key]
+                else:
+                    vals[key] = data[template_vals[key]]
+            if not data['Id'] in local_transsmart_ids:
+                model_obj.create(vals)
+            else:
+                rec_to_be_updated = local_data.filtered(
+                        lambda rec: rec.transsmart_id == data['Id'])
+                rec_to_be_updated.write(vals)
+
     @api.multi
     def sync_transsmart_models(self):
-        delivery_service_level_model = self.env['delivery.service.level']
-        delivery_service_level_time_model = self.env[
-                'delivery.service.level.time']
-        res_partner_model = self.env['res.partner']
-        transsmart_cost_center_model = self.env['transsmart.cost.center']
-        transsmart_package_type_model = self.env['transsmart.package.type']
-        local_data = delivery_service_level_model.search([])
-        local_transsmart_ids = [local.transsmart_id for local in local_data]
-        remote_data = self.get_transsmart_service().receive(
-                '/ServiceLevelOther')
-        for data in remote_data:
-            vals = {'code': data['Code'],
-                    'name': data['Name'],
-                    'transsmart_id': data['Id'],}
-            if not data['Id'] in local_transsmart_ids:
-                delivery_service_level_model.create(vals)
-                _logger.info("Created transsmart delivery.service.level %s" % (data['Id'],))
-            else:
-                rec_to_be_updated = local_data.filtered(
-                        lambda rec: rec.transsmart_id == data['Id'])
-                rec_to_be_updated.write(vals)
-                _logger.info("Updated Service Level {}".format(
-                    rec_to_be_updated.transsmart_id))
-
-        local_data = delivery_service_level_time_model.search([])
-        local_transsmart_ids = [local.transsmart_id for local in local_data]
-        remote_data = self.get_transsmart_service().receive(
-                '/ServiceLevelTime')
-        for data in remote_data:
-            vals = {'code': data['Code'],
-                    'name': data['Name'],
-                    'transsmart_id': data['Id']}
-            if not data['Id'] in local_transsmart_ids:
-                delivery_service_level_time_model.create(vals)
-                _logger.info("Created transsmart delivery.service.level.time %s" % (data['Id'],))
-            else:
-                rec_to_be_updated = local_data.filtered(
-                        lambda rec: rec.transsmart_id == data['Id'])
-                rec_to_be_updated.write(vals)
-                _logger.info("Updated Service Level Time {}".format(
-                    rec_to_be_updated.transsmart_id))
-
-        # this is how you indentify res.partners that are carriers 
-        # some carriers have a transsmart_id of 0, we cannot be sure to which
-        # carrier in transsmart our local res.partner maps to so we ignore it
-        local_data = res_partner_model.search(
-                [('transsmart_id', 'not in', [None, 0])])
-        local_transsmart_ids = [local.transsmart_id for local in local_data]
-        remote_data = self.get_transsmart_service().receive('/Carrier')
-        for data in remote_data:
-            vals = {'transsmart_code': data['Code'],
-                    'name': data['Name'],
-                    'supplier': True,
-                    'customer': False,
-                    'is_company': True,
-                    'transsmart_id': data['Id'],
-                    'category_id': [(4, self.get_transsmart_carrier_tag())]}
-            if not data['Id'] in local_transsmart_ids:
-                res_partner_model.create(vals)
-                _logger.info("Created transsmart res.partner %s" % (data['Id'],))
-            else:
-                rec_to_be_updated = local_data.filtered(
-                        lambda rec: rec.transsmart_id == data['Id'])
-                rec_to_be_updated.write(vals)
-                _logger.info("Updated res.partner {}".format(
-                    rec_to_be_updated.transsmart_id))
-
-        local_data = transsmart_cost_center_model.search([])
-        local_transsmart_ids = [local.transsmart_id for local in local_data]
-        remote_data = self.get_transsmart_service().receive('/Costcenter')
-        for data in remote_data:
-            vals = {'code': data['Code'],
-                    'name': data['Name'],
-                    'transsmart_id': data['Id']}
-            if not data['Id'] in local_transsmart_ids:
-                transsmart_cost_center_model.create(vals)
-                _logger.info("Created transsmart.cost.center %s" % (data['Code'],))
-            else:
-                rec_to_be_updated = local_data.filtered(
-                    lambda rec: rec.transsmart_id == data['Id'])
-                rec_to_be_updated.write(vals)
-                _logger.info("Updated transsmart.cost.center {}".format(
-                    rec_to_be_updated.transsmart_id))
-        # get the packages (box, pallet etc...)
-        local_data = transsmart_package_type_model.search([])
-        local_transsmart_ids = [local.transsmart_id for local in local_data]
-        remote_data = self.get_transsmart_service().receive('/Package')
-        for data in remote_data:
-            vals = {'name': data['Name'],
-                    'package_type': data['Type'],
-                    'length': data['Length'],
-                    'width': data['Width'],
-                    'height': data['Height'],
-                    'weight': data['Weight'],
-                    'is_default': data['IsDefault'],
-                    'transsmart_id': data['Id']}
-            if not data['Id'] in local_transsmart_ids:
-                transsmart_package_type_model.create(vals)
-                _logger.info("Created transsmart.package.type {}".format(
-                    data['Id']))
-            else:
-                rec_to_be_updated = local_data.filtered(
-                        lambda rec: rec.transsmart_id == data['Id'])
-                rec_to_be_updated.write(vals)
-                _logger.info("Updated transsmart.package.type {}".format(
-                    data['Id']))
+        self.log = 'Synchronisation started at {} \n'.format(
+                fields.Datetime.now())
+        for model_name in TRANS_MODELS_LOCAL:
+            self._sync_transsmart_model(model_name)
+        self.log += 'Synchronisation finished at {} \n'.format(
+                fields.Datetime.now())
         return True
 
     @api.multi

--- a/delivery_transsmart/models/res_partner.py
+++ b/delivery_transsmart/models/res_partner.py
@@ -34,7 +34,7 @@ class ResPartner(models.Model):
     transsmart_id = fields.Integer(
         "Transsmart ID")
     transsmart_package_type_id = fields.Many2one(
-            'transsmart.package.type',
+            'delivery.package.type',
             string='Package Type')
 
 

--- a/delivery_transsmart/models/res_partner.py
+++ b/delivery_transsmart/models/res_partner.py
@@ -33,7 +33,9 @@ class ResPartner(models.Model):
         string="Transsmart Code")
     transsmart_id = fields.Integer(
         "Transsmart ID")
-
+    transsmart_package_type_id = fields.Many2one(
+            'transsmart.package.type',
+            string='Package Type')
 
 
 

--- a/delivery_transsmart/models/stock_picking.py
+++ b/delivery_transsmart/models/stock_picking.py
@@ -107,7 +107,7 @@ class StockPicking(models.Model):
         if not colli_information:
             raise Warning(_(
                 "You have not set a package type for"
-                " the carrier {}, please do".format(carrier.name) + 
+                " the carrier %s, please do" % carrier.name +
                 " so by going to that carrier's form"
                 " Sales and Purchases page"))
         document = {
@@ -138,17 +138,15 @@ class StockPicking(models.Model):
             "AddressCity": self.partner_id.city or '',
             "AddressState": self.partner_id.state_id.name or '',
             "AddressCountry": self.partner_id.country_id.code or '',
-            "ColliInformation": [
-                {
-                    "PackagingType": colli_information._type,
-                    "Description": colli_information.name,
-                    "Quantity": 1,
-                    "Length": colli_information.length,
-                    "Width": colli_information.width,
-                    "Height": colli_information.height,
-                    "Weight": colli_information.weight,
-                }
-            ],
+            "ColliInformation": [{
+                "PackagingType": colli_information.package_type,
+                "Description": colli_information.name,
+                "Quantity": 1,
+                "Length": colli_information.length,
+                "Width": colli_information.width,
+                "Height": colli_information.height,
+                "Weight": colli_information.weight,
+                    }],
 
             "CarrierId": self.get_carrier_id(),
             "ServiceLevelTimeId": self.get_service_level_time_id(),

--- a/delivery_transsmart/models/transsmart_package_type.py
+++ b/delivery_transsmart/models/transsmart_package_type.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import fields, models
+
+
+class TranssmartPackageType(models.Model):
+    _name = 'transsmart.package.type'
+
+    name = fields.Char()
+    _type = fields.Char()
+    length = fields.Float()
+    width = fields.Float()
+    height = fields.Float()
+    weight = fields.Float()
+    isDefault = fields.Boolean()

--- a/delivery_transsmart/models/transsmart_package_type.py
+++ b/delivery_transsmart/models/transsmart_package_type.py
@@ -8,7 +8,7 @@ class TranssmartPackageType(models.Model):
     _name = 'transsmart.package.type'
 
     name = fields.Char()
-    _type = fields.Char()
+    package_type = fields.Char()
     length = fields.Float()
     width = fields.Float()
     height = fields.Float()

--- a/delivery_transsmart/models/transsmart_package_type.py
+++ b/delivery_transsmart/models/transsmart_package_type.py
@@ -13,4 +13,5 @@ class TranssmartPackageType(models.Model):
     width = fields.Float()
     height = fields.Float()
     weight = fields.Float()
-    isDefault = fields.Boolean()
+    is_default = fields.Boolean()
+    transsmart_id = fields.Integer()

--- a/delivery_transsmart/models/transsmart_package_type.py
+++ b/delivery_transsmart/models/transsmart_package_type.py
@@ -6,6 +6,7 @@ from openerp import fields, models
 
 class TranssmartPackageType(models.Model):
     _name = 'transsmart.package.type'
+    _description = 'Package types accepted by Transsmart'
 
     name = fields.Char()
     package_type = fields.Char()

--- a/delivery_transsmart/views/res_config_views.xml
+++ b/delivery_transsmart/views/res_config_views.xml
@@ -37,6 +37,9 @@
                             </div>
                         </div>
                     </group>
+                    <group name="Synchronisation log">
+                        <field name="log" nolabel="1" readonly="1" />
+                    </group>
                </form>
            </field>
         </record>

--- a/delivery_transsmart/views/res_partner.xml
+++ b/delivery_transsmart/views/res_partner.xml
@@ -1,0 +1,16 @@
+<openerp>
+    <data>
+
+        <record id="form_res_partner_carrier_package" model="ir.ui.view">
+            <field name="name">Carrier package field</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='date']" position="after">
+                    <field name="transsmart_package_type_id" />
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Refactors synchronization code and allows the user to set a different packaging type per carrier

1) Make sure that when the sync is done, server wins (local data will be overwritten)
2) A new table has been created that holds the package types of transsmart
3) A new field has been inserted on res_partner that you can use to set the default package type for that carrier
4) You must set a a default package type on the carriers or on the default carrier, if not the sync will fail with a rather non descriptive error message that will be fixed on a later pull request

@hbrunn @gcapalbo @NL66278 Please review this