### PR TITLE
[FIX] Don't remove delivery_service_level_time_id field when copying the stock_picking record

### DIFF
--- a/delivery_transsmart/models/stock_picking.py
+++ b/delivery_transsmart/models/stock_picking.py
@@ -307,7 +307,6 @@ class StockPicking(models.Model):
         context = context or {}
         default = default or {}
         default.update({
-            'delivery_service_level_time_id': False,
             'cost_center_id': False,
             'transsmart_confirmed': False,
             'transsmart_id': 0,


### PR DESCRIPTION
…the stock_picking record